### PR TITLE
Add support for opening file dialogs on Linux

### DIFF
--- a/BuildScripts/Linux_InstallDependencies.sh
+++ b/BuildScripts/Linux_InstallDependencies.sh
@@ -21,13 +21,23 @@ else
   exit 1
 fi
 
-# Install UI Dependency: gtk-4-dev
-echo "Installing libgtk-4-dev..."
-apt install -y libgtk-4-dev
+# Install GTK-3 for Zenity
+echo "Installing libgtk-3-dev..."
+apt install -y libgtk-3-dev
 if [ $? -eq 0 ]; then
-  echo "libgtk-4-dev installed successfully."
+  echo "libgtk-3-dev installed successfully."
 else
-  echo "An error occurred while installing libgtk-4-dev."
+  echo "An error occurred while installing libgtk-3-dev."
+  exit 1
+fi
+
+# Install Zenity for GUI dialogs
+echo "Installing zenity..."
+apt install -y zenity
+if [ $? -eq 0 ]; then
+  echo "zenity installed successfully."
+else
+  echo "An error occurred while installing zenity."
   exit 1
 fi
 

--- a/Editor/Source/EditorApp.cpp
+++ b/Editor/Source/EditorApp.cpp
@@ -1,6 +1,7 @@
 #include "kgpch.h"
 
 #include "EditorApp.h"
+#include "Kargono/Scripting/ScriptCompilerService.h"
 
 #include "API/EditorUI/ImGuiBackendAPI.h"
 
@@ -54,9 +55,13 @@ namespace Kargono
 	{
 		// Terminate engine services
 		EditorUI::EditorUIService::Terminate();
+		RuntimeUI::RuntimeUIService::Terminate();
 		Audio::AudioService::Terminate();
 		Scripting::ScriptService::Terminate();
 		AI::AIService::Terminate();
+		Scripting::ScriptCompilerService::Terminate();
+		Rendering::RenderingService::Shutdown();
+		Assets::AssetService::ClearAll();
 	}
 
 	void EditorApp::OnUpdate(Timestep ts)

--- a/Editor/Source/Windows/MainWindow/TestingPanel.cpp
+++ b/Editor/Source/Windows/MainWindow/TestingPanel.cpp
@@ -19,7 +19,6 @@ namespace Kargono::Panels
 
 
 	static FixedString256 newString;
-	static EditorUI::GridSpec testGrid{};
 	static EditorUI::TooltipSpec testTooltip{};
 
 	enum class TestTypes : uint32_t
@@ -47,23 +46,6 @@ namespace Kargono::Panels
 
 		m_TestHeader.m_Label = "directory/directory/file.txt";
 		newString = "Hahahaha";
-
-		// Add archetypes
-		testGrid.m_Label = "Testing Grid go burrrrrrr";
-		EditorUI::GridEntryArchetype newArchetype;
-		newArchetype.m_Icon = EditorUI::EditorUIService::s_IconDisplay;
-		newArchetype.m_OnLeftClick = [](EditorUI::GridEntry& currentEntry)
-		{
-			testTooltip.m_TooltipActive = true;
-		};
-		testGrid.AddEntryArchetype((uint32_t)TestTypes::Display, std::move(newArchetype));
-		for (std::size_t iteration{ 1 }; iteration < 10; iteration++)
-		{
-			EditorUI::GridEntry newEntry{};
-			newEntry.m_Label.SetFormat("NewEntry%i", iteration);
-			newEntry.m_ArchetypeID = (uint32_t)TestTypes::Display;
-			testGrid.AddEntry(std::move(newEntry));
-		}
 
 		// Test tooltip api
 		testTooltip.m_Label = "Test Tooltip";
@@ -264,7 +246,6 @@ namespace Kargono::Panels
 
 #if 0
 		EditorUI::EditorUIService::NavigationHeader(m_TestHeader);
-		EditorUI::EditorUIService::Grid(testGrid);
 
 		EditorUI::EditorUIService::Tooltip(testTooltip);
 #endif

--- a/Engine/Source/API/Platform/LinuxBackendAPI.h
+++ b/Engine/Source/API/Platform/LinuxBackendAPI.h
@@ -1,5 +1,4 @@
 #pragma once
 #if defined(KG_PLATFORM_LINUX) 
 #include <dlfcn.h>
-#include <gtk/gtk.h>
 #endif

--- a/Engine/Source/API/Platform/LinuxPlatformUtils.cpp
+++ b/Engine/Source/API/Platform/LinuxPlatformUtils.cpp
@@ -14,44 +14,87 @@
 
 namespace Kargono::Utility
 {
-    // TODO: Replace function stubs with actual linux implementations
+	static std::filesystem::path CallZenity(const std::string& command)
+	{
+		// Run command and receive pipe file with all logged messages (should just be the resultant file/folder)
+		FILE* pipe = popen(command.c_str(), "r");
+
+		// Ensure pipe file was generated
+		if (!pipe)
+		{
+			KG_WARN("Could not access pipe connection between engine and zenity");
+			return {};
+		}
+
+		// Get file/folder path from pipe
+		char buffer[128];
+		const char* text = fgets(buffer, sizeof(buffer), pipe);
+		
+		// Ensure text is returned by pipe
+		if (!text)
+		{
+			KG_INFO("No file/folder path was returned from linux dialog");
+			return {};
+		}
+
+		// Close the pipe and check for errors
+		if (pclose(pipe) == -1) 
+		{
+			KG_WARN("Could not properly close pipe to file/folder dialog");
+			return {};
+		}
+
+		// Remove trailing newline character and return path
+		std::string outputText {text};
+		outputText.pop_back();
+		return std::filesystem::path(outputText);
+	}
+
 	std::filesystem::path FileDialogs::OpenFile(const char* filter, const char* initialDirectory)
 	{
-		return {};
+		// Establish command using zenity (wrapper around gtk on linux for file dialogs)
+		std::string command = "zenity --file-selection --title=\"Open File\" ";
+
+		// Optionally add an initial directory
+		if (initialDirectory && strlen(initialDirectory) > 0)
+		{
+			command.append("--filename ");
+			command.append(initialDirectory);
+		}
+
+		// Ensure no error messages are logged into the pipe
+		command.append(" 2> /dev/null");
+
+		return CallZenity(command);
 	}
 	std::filesystem::path FileDialogs::SaveFile(const char* filter, const char* initialDirectory)
 	{
-		return {};
-	}
-#if 0
-	static void on_open_response (GtkDialog *dialog, int response)
-	{
-  		if (response == GTK_RESPONSE_ACCEPT)
-    	{
-      		//GtkFileChooser *chooser = GTK_FILE_CHOOSER (dialog);
-      		//g_autoptr(GFile) file = gtk_file_chooser_get_file (chooser);
-      		//open_file(file);
-        }
+		// Establish command using zenity (wrapper around gtk on linux for file dialogs)
+		std::string command = "zenity --file-selection --save --title=\"Save File\" ";
 
-  	    gtk_window_destroy (GTK_WINDOW (dialog));
+		// Optionally add an initial directory
+		if (initialDirectory)
+		{
+			command.append("--filename ");
+			command.append(initialDirectory);
+		}
+
+		// Ensure no error messages are logged into the pipe
+		command.append(" 2> /dev/null");
+
+		return CallZenity(command);
 	}
-#endif
 
 	std::filesystem::path FileDialogs::ChooseDirectory(const std::filesystem::path& initialPath)
 	{
-#if 0
-		// Initialize GTK
-        GtkWidget *dialog;
-        GtkFileChooserAction action = GTK_FILE_CHOOSER_ACTION_OPEN;
-        dialog = gtk_file_chooser_dialog_new ("Open Folder", (GtkWindow*)glfwGetWaylandWindow((GLFWwindow*)EngineService::GetActiveWindow().GetNativeWindow()), 
-										action, ("_Cancel"),
-                                        GTK_RESPONSE_CANCEL, ("_Open"), GTK_RESPONSE_ACCEPT, NULL);
+		// Establish basic choose directory command using zenity (wrapper around gtk on linux for file dialogs)
+		std::string command = "zenity --file-selection --directory --title=\"Choose Folder\" --filename ";
+		command.append(initialPath.string());
 
-  		gtk_window_present (GTK_WINDOW (dialog));
-  		g_signal_connect (dialog, "response", G_CALLBACK(on_open_response), NULL);
-#endif
-		// Return the selected folder path, or an empty path if canceled
-		return {};
+		// Ensure no error messages are logged into the pipe
+		command.append(" 2> /dev/null");
+
+		return CallZenity(command);
 	}
 }
 

--- a/Engine/Source/Kargono/Rendering/RenderingService.cpp
+++ b/Engine/Source/Kargono/Rendering/RenderingService.cpp
@@ -52,6 +52,8 @@ namespace Kargono::Rendering
 	}
 	void RenderingService::Shutdown()
 	{
+		s_Data.CameraUniformBuffer.reset();
+		s_Data.DrawCalls.clear();
 	}
 	void RenderingService::BeginScene(const Camera& camera, const Math::mat4& transform)
 	{

--- a/Engine/Source/Kargono/RuntimeUI/RuntimeUI.cpp
+++ b/Engine/Source/Kargono/RuntimeUI/RuntimeUI.cpp
@@ -53,13 +53,13 @@ namespace Kargono::RuntimeUI
 
 	void RuntimeUIService::Terminate()
 	{
-		// Terminate Static Variables
-		s_RuntimeUIContext = nullptr;
-
 		// Terminate Window/Widget Rendering Data
 		{
 			delete s_RuntimeUIContext->m_BackgroundInputSpec.m_ShapeComponent;
 		}
+
+		// Terminate Static Variables
+		s_RuntimeUIContext = nullptr;
 
 		// Verify Termination
 		KG_VERIFY(true, "Runtime UI Engine Terminate");

--- a/Engine/Source/Kargono/Scripting/ScriptCompilerCommon.h
+++ b/Engine/Source/Kargono/Scripting/ScriptCompilerCommon.h
@@ -562,7 +562,6 @@ namespace Kargono::Scripting
 		std::unordered_map<std::string, std::string> NamespaceDescriptions {};
 		std::unordered_map<std::string, FunctionNode> FunctionDefinitions {};
 		std::vector<InitializationListType> InitListTypes {};
-
 		std::unordered_set<std::string> AllMessageTypes{};
 	public:
 		PrimitiveType GetPrimitiveTypeFromName(const std::string& name)
@@ -575,6 +574,17 @@ namespace Kargono::Scripting
 			return {};
 		}
 	public:
+
+		void Clear()
+		{
+			Keywords.clear();
+			PrimitiveTypes.clear();
+			NamespaceDescriptions.clear();
+			FunctionDefinitions.clear();
+			InitListTypes.clear();
+			AllMessageTypes.clear();
+		}
+
 		operator bool() const
 		{
 			return Keywords.size() > 0 || PrimitiveTypes.size() > 0 || FunctionDefinitions.size() > 0;

--- a/Engine/Source/Kargono/Scripting/ScriptCompilerService.cpp
+++ b/Engine/Source/Kargono/Scripting/ScriptCompilerService.cpp
@@ -68,6 +68,11 @@ namespace Kargono::Scripting
 		{ ScriptTokenType::PrimitiveType, "float" }
 	};
 
+	void ScriptCompilerService::Terminate()
+	{
+		s_ActiveLanguageDefinition.Clear();
+	}
+
 	std::string ScriptCompilerService::CompileScriptFile(const std::filesystem::path& scriptLocation)
 	{
 		// Lazy loading KGScript language def

--- a/Engine/Source/Kargono/Scripting/ScriptCompilerService.h
+++ b/Engine/Source/Kargono/Scripting/ScriptCompilerService.h
@@ -20,6 +20,11 @@ namespace Kargono::Scripting
 	{
 	public:
 		//==============================
+		// Lifecycle Functions
+		//==============================
+		static void Terminate();
+		
+		//==============================
 		// External API
 		//==============================
 		static std::string CompileScriptFile(const std::filesystem::path& scriptLocation);

--- a/Runtime/Source/RuntimeApp.cpp
+++ b/Runtime/Source/RuntimeApp.cpp
@@ -88,9 +88,13 @@ namespace Kargono
 	{
 		OnStop();
 
+		// Terminate engine services
+		RuntimeUI::RuntimeUIService::Terminate();
 		Audio::AudioService::Terminate();
+		Scripting::ScriptService::Terminate();
 		AI::AIService::Terminate();
-
+		Rendering::RenderingService::Shutdown();
+		Assets::AssetService::ClearAll();
 	}
 
 	void RuntimeApp::OnUpdate(Timestep ts)


### PR DESCRIPTION
- Add gtk-3 and zenity as Linux dependencies for Linux_InstallDependencies.sh
-  Properly handle termination of multiple systems in the engine/editor/runtime including ScriptCompilerService, RenderingService, etc...
- Use Zenity to open file dialogs on Linux in LinuxPlatformUtils.cpp