### PR TITLE
Implement PageAlloc and MirrorAlloc and Start Allocator Review

### DIFF
--- a/Engine/Source/Kargono/Memory/LinearAlloc.h
+++ b/Engine/Source/Kargono/Memory/LinearAlloc.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <utility>
 #include <cstdint>
+
+#include <new>
+#include <utility>
 
 namespace Kargono::Memory
 {
@@ -33,19 +35,21 @@ namespace Kargono::Memory
 			// Resource for placement new: https://www.geeksforgeeks.org/placement-new-operator-cpp/
 
 			// Allocate memory for one or more objects of the specified type
-			Type* returnPtr = new (AllocRaw(sizeof(Type) * Count, Align)) Type(std::forward<decltype(args)>(args)...);
+			uint8_t* buffer = AllocRaw(sizeof(Type) * Count, Align);
+			if (buffer == nullptr)
+				return nullptr;
 
-			// Return pointer to memory (AllocRaw could return nullptr)
-			return returnPtr;
+			// Construct objects in-place with the given args
+			return new (buffer) Type(std::forward<decltype(args)>(args)...);
 		}
-
-		// TODO: Optionally add resize allocation method here: https://www.gingerbill.org/article/2019/02/08/memory-allocation-strategies-002/
 
 	public:
 		//==============================
 		// Manage Allocator
 		//==============================
 		void Reset();
+
+		// TODO: Optionally add resize allocation method here: https://www.gingerbill.org/article/2019/02/08/memory-allocation-strategies-002/
 
 	private:
 		uint8_t* m_Buffer{ nullptr };

--- a/Engine/Source/Kargono/Memory/MemoryCommon.h
+++ b/Engine/Source/Kargono/Memory/MemoryCommon.h
@@ -13,6 +13,16 @@ namespace Kargono::Utility
 		return (x & (x - 1)) == 0;
 	}
 
+	inline bool IsAlignedTo(uintptr_t pointer, size_t alignment)
+	{
+		KG_ASSERT(IsPowerOfTwo(alignment));
+
+		uintptr_t mask = (alignment - 1);
+		uintptr_t res = pointer & mask;
+
+		return res == 0;
+	}
+
 	inline uintptr_t AlignBackward(uintptr_t pointer, size_t alignment)
 	{
 		KG_ASSERT(IsPowerOfTwo(alignment));

--- a/Engine/Source/Kargono/Memory/MemoryCommon.h
+++ b/Engine/Source/Kargono/Memory/MemoryCommon.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <cstddef>
 #include <cstdint>
 
 namespace Kargono::Utility
@@ -11,27 +13,24 @@ namespace Kargono::Utility
 		return (x & (x - 1)) == 0;
 	}
 
+	inline uintptr_t AlignBackward(uintptr_t pointer, size_t alignment)
+	{
+		KG_ASSERT(IsPowerOfTwo(alignment));
+
+		uintptr_t mask = ~(alignment - 1);
+		uintptr_t res = pointer & mask;
+
+		return res;
+	}
+
 	inline uintptr_t AlignForward(uintptr_t pointer, size_t alignment)
 	{
-		uintptr_t returnPtr;
-		uintptr_t alignmentInt;
-		uintptr_t modulo;
-
 		// Most/all architectures use power-of-two alignment
-		KG_ASSERT(Utility::IsPowerOfTwo((uintptr_t)alignment));
+		KG_ASSERT(IsPowerOfTwo(alignment));
 
-		returnPtr = pointer;
-		alignmentInt = alignment;
+		uintptr_t upper_bound = pointer + (alignment - 1);
+		uintptr_t res = AlignBackward(upper_bound, alignment);
 
-		// Bitwise operation to calculate modulo for powers of two
-		modulo = returnPtr & (alignmentInt - 1);
-
-		// Move the pointer by the additive inverse if a modulo (remainder) exists
-		if (modulo != 0)
-		{
-			returnPtr += alignmentInt - modulo;
-		}
-
-		return returnPtr;
+		return res;
 	}
 }

--- a/Engine/Source/Kargono/Memory/SystemAlloc.cpp
+++ b/Engine/Source/Kargono/Memory/SystemAlloc.cpp
@@ -1,22 +1,20 @@
 #include "kgpch.h"
 
+#include "Kargono/Memory/MemoryCommon.h"
 #include "Kargono/Memory/SystemAlloc.h"
-
-#define ALIGN_PREV(v, align) ((v) & ~((align) - 1))
-#define ALIGN_NEXT(v, align) ALIGN_PREV((v) + ((align) - 1), (align))
 
 namespace Kargono::Memory
 {
 	uint8_t* System::GenAlloc(size_t dataSize, size_t alignment)
 	{
+		KG_ASSERT(Utility::IsPowerOfTwo(alignment));
+
+		size_t upper_bound = dataSize + (alignment - 1);
+
 		// TODO: Look into VirtualAlloc() and mmap() for bigger allocations
-		uintptr_t returnPtr = (uintptr_t)malloc(dataSize + alignment);
+		uintptr_t ptr = (uintptr_t) malloc(upper_bound);
+		uintptr_t res = Utility::AlignForward(ptr, alignment);
 
-		returnPtr = ALIGN_NEXT(returnPtr, alignment);
-
-		return (uint8_t*)returnPtr;
+		return (uint8_t*) res;
 	}
 }
-
-#undef ALIGN_PREV
-#undef ALIGN_NEXT

--- a/Engine/Source/Kargono/Memory/SystemAlloc.cpp
+++ b/Engine/Source/Kargono/Memory/SystemAlloc.cpp
@@ -3,6 +3,79 @@
 #include "Kargono/Memory/MemoryCommon.h"
 #include "Kargono/Memory/SystemAlloc.h"
 
+#if defined(_WIN32)
+# include <windows.h>
+# include <memoryapi.h>
+namespace {
+	uint8_t* Win32PageAlloc(size_t size, size_t alignment)
+	{
+		KG_ASSERT(Kargono::Utility::IsPowerOfTwo(alignment));
+
+		/* TODO: implement hugepage aware page alloc
+		 * ---
+		 *  see: https://learn.microsoft.com/en-us/windows/win32/memory/large-page-support
+		 */
+
+		uintptr_t aligned_size = Kargono::Utility::AlignForward(size, alignment);
+
+		DWORD prot = PAGE_READWRITE;
+		DWORD flags = MEM_RESERVE | MEM_COMMIT;
+		LPVOID ptr = VirtualAlloc(nullptr, aligned_size, flags, prot);
+
+		return (uint8_t*) ptr;
+	}
+}
+
+#elif defined(__linux__)
+# include <sys/mman.h>
+namespace {
+	uint8_t* LinuxPageAlloc(size_t size, size_t alignment)
+	{
+		KG_ASSERT(Kargono::Utility::IsPowerOfTwo(alignment));
+		KG_ASSERT(Kargono::Memory::MEM_ALIGN_4_KIB <= alignment);
+
+		/* hugepage aware page alloc:
+		 *  1. map a memory region with PROT_NONE pages (overallocating
+		 *     by up to (alignment - 1) bytes)
+		 *
+		 *  2. map a new memory region with PROT_READ|PROT_WRITE pages
+		 *     from within the previous memory region, ensuring that we
+		 *     allocate on a (huge)page-aligned address. this removes
+		 *     the previous PROT_NONE mapping
+		 *
+		 *  3. advise that the new memory region is to be backed by
+		 *     huge pages if possible (i.e. if alignment is sufficient)
+		 *
+		 *  4. unmap any remaining PROT_NONE pages preceeding our new
+		 *     memory region
+		 */
+
+		int prot = PROT_READ | PROT_WRITE;
+		int flags = MAP_PRIVATE | MAP_ANONYMOUS;
+
+		size_t aligned_size = Kargono::Utility::AlignForward(size, alignment);
+		void* unaligned_ptr = mmap(nullptr, aligned_size, PROT_NONE, flags, -1, 0);
+		if (unaligned_ptr == MAP_FAILED)
+			return nullptr;
+
+		uintptr_t aligned_base = Kargono::Utility::AlignForward((uintptr_t) unaligned_ptr, alignment);
+		void* aligned_ptr = mmap((void*) aligned_base, size, prot, flags | MAP_FIXED, -1, 0);
+		if (aligned_ptr == MAP_FAILED)
+			return nullptr;
+
+		if (Kargono::Utility::IsAlignedTo(aligned_base, Kargono::Memory::MEM_ALIGN_2_MIB))
+			madvise(aligned_ptr, size, MADV_HUGEPAGE);
+
+		munmap(unaligned_ptr, aligned_base - (uintptr_t) unaligned_ptr);
+
+		return (uint8_t*) aligned_ptr;
+	}
+}
+
+#else
+# error "Unknown platform, must be one of: windows linux"
+#endif
+
 namespace Kargono::Memory
 {
 	uint8_t* System::GenAlloc(size_t dataSize, size_t alignment)
@@ -11,10 +84,23 @@ namespace Kargono::Memory
 
 		size_t upper_bound = dataSize + (alignment - 1);
 
-		// TODO: Look into VirtualAlloc() and mmap() for bigger allocations
 		uintptr_t ptr = (uintptr_t) malloc(upper_bound);
 		uintptr_t res = Utility::AlignForward(ptr, alignment);
 
 		return (uint8_t*) res;
+	}
+
+	uint8_t* System::PageAlloc(size_t dataSize, size_t alignment)
+	{
+		if (alignment < MEM_ALIGN_4_KIB)
+			alignment = MEM_ALIGN_4_KIB;
+
+#if defined(_WIN32)
+		return Win32PageAlloc(dataSize, alignment);
+#elif defined(__linux__)
+		return LinuxPageAlloc(dataSize, alignment);
+#else
+		return nullptr;
+#endif
 	}
 }

--- a/Engine/Source/Kargono/Memory/SystemAlloc.h
+++ b/Engine/Source/Kargono/Memory/SystemAlloc.h
@@ -14,6 +14,21 @@ namespace Kargono::Memory
 	public:
 		static uint8_t* GenAlloc(size_t dataSize, size_t alignment);
 		static uint8_t* PageAlloc(size_t dataSize, size_t alignment);
+
+		struct MirrorAllocResult {
+#if defined(_WIN32)
+# include <windows.h>
+			HANDLE memfd;
+#elif defined(__linux__)
+			int memfd;
+#else
+# error "Unknown platform, must be one of: windows linux"
+#endif
+			uint8_t* ptr;
+			size_t len, cap;
+		};
+
+		static MirrorAllocResult MirrorAlloc(size_t dataSize, size_t mirrors);
 	};
 }
 

--- a/Engine/Source/Kargono/Memory/SystemAlloc.h
+++ b/Engine/Source/Kargono/Memory/SystemAlloc.h
@@ -5,6 +5,10 @@
 
 namespace Kargono::Memory
 {
+	constexpr size_t MEM_ALIGN_4_KIB = 4 * 1024;
+	constexpr size_t MEM_ALIGN_2_MIB = 2 * 1024 * 1024;
+	constexpr size_t MEM_ALIGN_1_GIB = 1 * 1024 * 1024 * 1024;
+
 	class System
 	{
 	public:


### PR DESCRIPTION
This PR adds support for a full `PageAlloc` implementation for both windows and linux, as well as a virtual-memory backed circular buffer imeplementation in `MirrorAlloc` (again, for both windows and linux).

Additionally, this PR starts some cleanup and review of the various memory allocators provided under `Kargono::Memory`.

The `Utility::XXX` functions were made simpler and more amenable to being made `constexpr`, which should be a free performance win. They were also hopefully made slightly more "self-documenting".

The `LinearAlloc` implementation was fine, but could be made to avoid some branching and be simplified.

The `PoolAlloc` and `StackAlloc` implementations are a bit more complicated, in that their "optimal" implementation depends on how they will be used.

`PoolAlloc` could be thought of as a pool of fixed-sized buffers, a pool of variably-sized buffers (of a minimum size), or as an object pool. Each case has slightly different semantics, and a slightly different "optimal" implementation. For example, I tend to implement object pools as an intrusive freelist (each object has a `FreeListNode` member, and the "pool" is essentially a linked list of said `FreeListNode` members). This avoids any issues with object alignment v.s. `FreeListNode` alignment, and any issues with memory fragmentation. For fixed-size buffers, this can be simplified to something resembling the current implementation. For variably-sized buffers, the free list nodes obviously need to track each individual buffer's pointer and capacity, and the next free list node.

All that to say that for now, I think the `PoolAlloc` implementation is fine, but that it could probably do with being specialised into an `ObjectPool<T>` class, a `BufferPool` (variably-sized buffer pool) class, and a `BlockAlloc` (fixed-size buffer allocator) class.

`StackAlloc` suffers from the fact that the stack region headers are kept inline with the data. For extreme alignment values, this means a lot of internal fragmentation. I believe that the fix for this is to switch to keeping the stack region headers out-of-line with the data (i.e. return a compound `template <typename T> struct StackAlloc::Result { T* ptr; size_t len; private: uint8_t *saveptr; friend StackAlloc; }` result type instead of a `uint8_t *`). This makes using the result trivially harder (you need to use `result.ptr` instead of `result` directly), but it also means that we can provide more information to the caller (in this case, the allocation bounds).

I would also eventually want to add a `BuddyAlloc` / `HeapAlloc` that mimics the system `malloc()` over user-provided memory regions, but I think that is a bit of an overreach (I don't think there are many places where general allocation is necessary; there should always be some kind of lifetime you can make use of to limit the needed allocation to a `LinearAlloc`, `BlockAlloc`, or `StackAlloc`). Let me know if this is something you think would be genuinely useful.